### PR TITLE
Update binaries and uses aws-cli v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-FROM alpine:3.12.0
+FROM frolvlad/alpine-glibc:alpine-3.12
 
 LABEL maintainer="Wildlife Studios"
 
 ARG BASH_VERSION=5.0.17-r0
-ARG CURL_VERSION=7.69.1-r1
+ARG CURL_VERSION=7.69.1-r3
 ARG GREP_VERSION=3.4-r0
 ARG GIT_VERSION=2.26.2-r0
-ARG PYTHON_VERSION=3.8.5-r0
 ARG JQ_VERSION=1.6-r1
+ARG MAKE_VERSION=4.3-r0
+ARG PYTHON_VERSION=3.8.5-r0
 ARG PY3_PIP_VERSION=20.1.1-r0
 ARG ZIP_VERSION=3.0-r8
-ARG CONFTEST_VERSION=0.21.0
 
-ARG VAULT_VERSION=1.3.4
+ARG VAULT_VERSION=1.6.0
+ARG CONFTEST_VERSION=0.22.0
 ARG TFENV_VERSION=1.1.1
-ARG AWSCLI_VERSION=1.18.27
-ARG MAKE_VERSION=4.3-r0
-ARG KUBECTL_VERSION=v1.18.5
+ARG KUBECTL_VERSION=v1.20.0
 
 # Base dependencies
 RUN apk update && \
@@ -38,8 +37,8 @@ RUN curl https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VER
       chmod +x /usr/bin/vault
 
 # conftest
-RUN wget https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz && \
-    tar xzf conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz -C /usr/bin/
+RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v0.22.0/conftest_0.22.0_Linux_x86_64.tar.gz --output - | \
+      tar -xzf - -C /usr/local/bin
 
 # tfenv (terraform)
 RUN git clone -b ${TFENV_VERSION} --single-branch --depth 1 \
@@ -47,7 +46,11 @@ RUN git clone -b ${TFENV_VERSION} --single-branch --depth 1 \
       ln -s /opt/tfenv/bin/* /usr/local/bin
 
 # AWS CLI
-RUN pip3 install awscli==${AWSCLI_VERSION}
+RUN curl -L https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip --output - | \
+      busybox unzip -d /tmp/ - && \
+      chmod +x -R /tmp/aws && \
+      ./tmp/aws/install && \
+      rm -rf ./tmp/aws
 
 # Kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /bin/kubectl

--- a/README.md
+++ b/README.md
@@ -1,21 +1,30 @@
-[![Repository on Quay](https://quay.io/repository/tfgco/iac-ci/status "Repository on Quay")](https://quay.io/repository/tfgco/iac-ci)
+[![Build status](https://github.com/topfreegames/iac-docker-image/workflows/Publish%20new%20Docker%20image/badge.svg
+)](https://github.com/topfreegames/iac-docker-image/actions)
+[![Docker Repository on Docker Hub](https://img.shields.io/badge/Docker%20Hub-ready-%23099cec)](https://hub.docker.com/r/tfgco/iac-ci)
+[![Docker Repository on Quay](https://img.shields.io/badge/Quay.io-ready-%23BE0000)](https://quay.io/repository/tfgco/iac-ci)
 
-[![Docker Repository on Docker Hub](https://img.shields.io/docker/v/tfgco/iac-ci?label=docker%20hub "Docker Repository on Docker Hub")](https://hub.docker.com/r/tfgco/iac-ci)
+# Infrastructe as Code Image
 
-# Base image used for our IaC CI pipeline
+Image used in our Infrastructe as Code pipelines.
 
-This image is based on alpine linux and includes:
+- `bash`
+- `curl`
+- `conftest`
+- `grep`
+- `git`
+- `jq`
+- `kubectl`
+- `make`
+- `python3`
+- `pip43`
+- `tfenv`
+- `vault`
+- `zip`
 
-- bash
-- curl
-- git
-- vault
-- tfenv (terraform)
-- awscli
-- make
-- jq
-- kubectl
+## Latest versions
 
+[![Normal Docker Image Size](https://img.shields.io/docker/v/tfgco/iac-ci/latest?label=normal%20version&color=blue)](https://hub.docker.com/r/tfgco/iac-ci)
+[![Normal Docker Image Size](https://img.shields.io/docker/image-size/tfgco/iac-ci/latest?label=normal%20image%20size&color=lightgray)](https://hub.docker.com/r/tfgco/iac-ci)
 ## Hosted at
 
 Quay: https://quay.io/repository/tfgco/iac-ci

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 Image used in our Infrastructe as Code pipelines.
 
+- `awscli`
 - `bash`
 - `curl`
 - `conftest`
@@ -17,9 +18,14 @@ Image used in our Infrastructe as Code pipelines.
 - `make`
 - `python3`
 - `pip43`
+- `terragrunt`
 - `tfenv`
 - `vault`
 - `zip`
+
+## AWSCLI notes
+
+This image uses awscli v1 by default. To enable usage of awscli v2 set the AWSCLIV2 environment variable to any value.  
 
 ## Latest versions
 

--- a/workflows/docker-build-push.yml
+++ b/workflows/docker-build-push.yml
@@ -1,0 +1,45 @@
+name: Publish new Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dockerhub-build-push:
+    name: DockerHub Build and Push
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Get the current release version 
+      id: vars
+      run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag tfgco/iac-ci:latest
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+    - name: Push the latest Docker image
+      run: docker push tfgco/iac-ci:latest
+    - name: Tag the release Docker image
+      run: docker tag tfgco/iac-ci:latest tfgco/iac-ci:${{steps.vars.outputs.tag}} 
+    - name: Push the tagged release Docker image
+      run: docker push tfgco/iac-ci:${{steps.vars.outputs.tag}} 
+  quayio-build-push:
+    name: Quay.io Build and Push
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Get the current release version 
+      id: vars
+      run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag quay.io/tfgco/iac-ci:latest
+    - name: Login to Quay.io Registry
+      run: echo ${{ secrets.QUAYIO_TOKEN }} | docker login -u ${{ secrets.QUAYIO_USERNAME }} --password-stdin quay.io
+    - name: Push the latest Docker image
+      run: docker push quay.io/tfgco/iac-ci:latest
+    - name: Tag the release Docker image
+      run: docker tag quay.io/tfgco/iac-ci:latest quay.io/tfgco/iac-ci:${{steps.vars.outputs.tag}} 
+    - name: Push the tagged release Docker image
+      run: docker push quay.io/tfgco/iac-ci:${{steps.vars.outputs.tag}} 


### PR DESCRIPTION
This PR will add aws-cli-v2 to the Docker image while also updating some of other binaries.

I'm also adding a new workflow to build the Docker image on Github instead of using Quay && Dockerhub CIs.

You **should NOT** release this version without an announcement for the team, as many users pin the image on latest and this would create a breaking change for them. 

I'm pushing this code now as this will be something that will be needed in near future.