### PR TITLE
add rover to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ARG TERRAGRUNT=v0.29.7
 ARG OPA_VERSION=v0.29.4
 ARG PSQL_VERSION=12.8-r0
 ARG MYSQL_VERSION=10.4.21-r0
+ARG ROVER_VERSION=0.2.2
 
 # Base dependencies
 RUN apk update && \
@@ -50,6 +51,13 @@ RUN curl -fsSL -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/re
 # conftest
 RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz --output - | \
       tar -xzf - -C /usr/local/bin
+
+# rover
+RUN curl -LO https://github.com/im2nguyen/rover/releases/download/v${ROVER_VERSION}/rover_${ROVER_VERSION}_linux_amd64.zip && \
+        busybox unzip -d /tmp/ rover_${ROVER_VERSION}_linux_amd64.zip && \
+        mv /tmp/rover_v${ROVER_VERSION} /usr/bin/rover && \
+        chmod +x /usr/bin/rover && \
+        rm -r /tmp/*
 
 # tfenv (terraform)
 RUN git clone -b ${TFENV_VERSION} --single-branch --depth 1 \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build status](https://github.com/topfreegames/iac-docker-image/workflows/Publish%20new%20Docker%20image/badge.svg
-)](https://github.com/topfreegames/iac-docker-image/actions)
+[![Build status](https://github.com/topfreegames/iac-docker-image/workflows/Publish%20new%20Docker%20image/badge.svg)](https://github.com/topfreegames/iac-docker-image/actions)
 [![Docker Repository on Docker Hub](https://img.shields.io/badge/Docker%20Hub-ready-%23099cec)](https://hub.docker.com/r/tfgco/iac-ci)
 [![Docker Repository on Quay](https://img.shields.io/badge/Quay.io-ready-%23BE0000)](https://quay.io/repository/tfgco/iac-ci)
 
@@ -23,15 +22,17 @@ Image used in our Infrastructure as Code pipelines.
 - `tfenv`
 - `vault`
 - `zip`
+- `rover`
 
 ## AWSCLI notes
 
-This image uses awscli v1 by default. To enable usage of awscli v2 set the AWSCLIV2 environment variable to any value.  
+This image uses awscli v1 by default. To enable usage of awscli v2 set the AWSCLIV2 environment variable to any value.
 
 ## Latest versions
 
 [![Normal Docker Image Size](https://img.shields.io/docker/v/tfgco/iac-ci/latest?label=normal%20version&color=blue)](https://hub.docker.com/r/tfgco/iac-ci)
 [![Normal Docker Image Size](https://img.shields.io/docker/image-size/tfgco/iac-ci/latest?label=normal%20image%20size&color=lightgray)](https://hub.docker.com/r/tfgco/iac-ci)
+
 ## Hosted at
 
 Quay: https://quay.io/repository/tfgco/iac-ci


### PR DESCRIPTION
This PR will add the rover binary to the image so we can have interactive visualization of terraform plans to understand changes to our infrastructure resources.