### PR TITLE
feat(deps): bump alpine to 3.23 and removes rover

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -29,6 +29,7 @@ jobs:
           docker run --rm iac-ci:test "aws --version"
           docker run --rm iac-ci:test "kubectl version --client"
           docker run --rm iac-ci:test "helm version"
+          docker run --rm iac-ci:test "helm plugin list | awk 'NR>1 {print \$1}' | grep -qx diff || { echo 'ERROR: helm-diff plugin not installed'; helm plugin list; exit 1; }"
           docker run --rm iac-ci:test "tfenv --version"
           docker run --rm iac-ci:test "command -v terraform"
           docker run --rm iac-ci:test "terragrunt --version"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -40,5 +40,4 @@ jobs:
           docker run --rm iac-ci:test "flux --version"
           docker run --rm iac-ci:test "psql --version"
           docker run --rm iac-ci:test "mysql --version"
-          docker run --rm iac-ci:test "rover --version"
           echo "✅ All basic command tests passed!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN apkArch="$(apk --print-arch)"; \
       x86_64) arch=amd64 ;; \
       aarch64)  arch=arm64 ;; \
     esac; \
-    curl -L -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl && \
+    curl -L -o /bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl && \
     chmod u+x /bin/kubectl
 
 #Helm Diff

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,77 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 LABEL maintainer="Wildlife Studios"
 
-ARG BASH_VERSION=5.2.37
-ARG CURL_VERSION=8.14.1
-ARG GREP_VERSION=3.11
-ARG GIT_VERSION=2.47.3
-ARG JQ_VERSION=1.7.1
-ARG MAKE_VERSION=4.4.1
-ARG PYTHON_VERSION=3.12.12
-ARG PY3_PIP_VERSION=24.3.1
-ARG ZIP_VERSION=3.0
-ARG OPENSSH_VERSION=9.9_p2
-ARG KUSTOMIZE_VERSION=5.5.0
-ARG FLUX_VERSION=2.4.0
-ARG AWS_CLI_VERSION=2.22.10
-ARG HELM_VERSION=3.16.3
-ARG YQ_VERSION=4.44.5
+# renovate: datasource=repology depName=alpine_3_23/bash versioning=loose
+ARG BASH_VERSION=5.3
 
+# renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
+ARG CURL_VERSION=8.17.0
+
+# renovate: datasource=repology depName=alpine_3_23/grep versioning=loose
+ARG GREP_VERSION=3.12
+
+# renovate: datasource=repology depName=alpine_3_23/git versioning=loose
+ARG GIT_VERSION=2.52.0
+
+# renovate: datasource=github-releases depName=jqlang/jq
+ARG JQ_VERSION=1.8.1
+
+# renovate: datasource=repology depName=alpine_3_23/make versioning=loose
+ARG MAKE_VERSION=4.4.1
+
+# renovate: datasource=repology depName=alpine_3_23/python3 versioning=loose
+ARG PYTHON_VERSION=3.12.12
+
+# renovate: datasource=pypi depName=pip
+ARG PY3_PIP_VERSION=25.1.1
+
+# renovate: datasource=repology depName=alpine_3_23/zip versioning=loose
+ARG ZIP_VERSION=3.0
+
+# renovate: datasource=repology depName=alpine_3_23/openssh versioning=loose
+ARG OPENSSH_VERSION=10.2_p1
+
+# renovate: datasource=repology depName=alpine_3_23/kustomize versioning=loose
+ARG KUSTOMIZE_VERSION=5.7.1
+
+# renovate: datasource=repology depName=alpine_3_23/flux versioning=loose
+ARG FLUX_VERSION=2.7.3
+
+# renovate: datasource=repology depName=alpine_3_23/aws-cli versioning=loose
+ARG AWS_CLI_VERSION=2.32.7
+
+# renovate: datasource=repology depName=alpine_3_23/helm versioning=loose
+ARG HELM_VERSION=3.19.0
+
+# renovate: datasource=repology depName=alpine_3_23/yq-go versioning=loose
+ARG YQ_VERSION=4.49.2
+
+# renovate: datasource=github-releases depName=hashicorp/vault
 ARG VAULT_VERSION=1.17.5
+
+# renovate: datasource=github-releases depName=open-policy-agent/conftest
 ARG CONFTEST_VERSION=0.59.0
+
+# renovate: datasource=github-releases depName=tfutils/tfenv
 ARG TFENV_VERSION=v3.0.0
+
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
 ARG KUBECTL_VERSION=v1.28.13
+
+# renovate: datasource=github-releases depName=gruntwork-io/terragrunt
 ARG TERRAGRUNT=v0.69.9
-ARG PSQL_VERSION=15.13-r0
-ARG MYSQL_VERSION=11.4.8-r0
+
+# renovate: datasource=repology depName=alpine_3_23/postgresql16-client versioning=loose
+ARG PSQL_VERSION=16.11-r0
+
+# renovate: datasource=repology depName=alpine_3_23/mysql-client versioning=loose
+ARG MYSQL_VERSION=11.4.9-r0
+
+# renovate: datasource=github-releases depName=rsafonseca/helm-diff
 ARG HELM_DIFF_VERSION=v3.9.10
+
+# renovate: datasource=github-releases depName=open-policy-agent/opa
 ARG OPA_VERSION=v1.4.2
 
 # Base dependencies
@@ -40,7 +86,7 @@ RUN apk update && \
     py3-pip~=${PY3_PIP_VERSION}  \
     jq~=${JQ_VERSION} \
     zip~=${ZIP_VERSION} \
-    postgresql15-client~=${PSQL_VERSION} \
+    postgresql16-client~=${PSQL_VERSION} \
     mysql-client~=${MYSQL_VERSION} \
     openssh~=${OPENSSH_VERSION} \
     kustomize~=${KUSTOMIZE_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ ARG KUBECTL_VERSION=v1.28.13
 ARG TERRAGRUNT=v0.69.9
 ARG PSQL_VERSION=15.13-r0
 ARG MYSQL_VERSION=11.4.8-r0
-ARG ROVER_VERSION=0.3.3
 ARG HELM_DIFF_VERSION=v3.9.10
 ARG OPA_VERSION=v1.4.2
 
@@ -77,18 +76,6 @@ RUN apkArch="$(apk --print-arch)"; \
     esac; \
     curl -L https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${arch}.tar.gz --output - | \
     tar -xzf - -C /usr/local/bin
-
-# rover
-RUN apkArch="$(apk --print-arch)"; \
-    case "$apkArch" in \
-      x86_64) arch=amd64 ;; \
-      aarch64)  arch=arm64 ;; \
-    esac; \
-    curl -LO https://github.com/im2nguyen/rover/releases/download/v${ROVER_VERSION}/rover_${ROVER_VERSION}_linux_amd64.zip && \
-    busybox unzip -d /tmp/ rover_${ROVER_VERSION}_linux_amd64.zip && \
-    mv /tmp/rover_v${ROVER_VERSION} /usr/bin/rover && \
-    chmod +x /usr/bin/rover && \
-    rm -r /tmp/* && rm rover_${ROVER_VERSION}_linux_amd64.zip
 
 # tfenv (terraform)
 RUN git clone -b ${TFENV_VERSION} --single-branch --depth 1 \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Image used in our Infrastructure as Code pipelines.
 - `postgresql-client`
 - `python3`
 - `pip3`
-- `rover`
 - `terragrunt`
 - `tfenv`
 - `vault`


### PR DESCRIPTION
- Upgrades alpine from 3.21 to 3.23
- Upgrades other components to be compliant with the new base image's version
- Removes rover component
- Points to up-to-date Kubernetes address for binaries
- Complements test pipeline to ensure helm plugin is being installed
- Adapts Dockerfile so RenovateBot can start tracking components installed in the image